### PR TITLE
Fix read buffer termination

### DIFF
--- a/bsjson.c
+++ b/bsjson.c
@@ -583,7 +583,7 @@ JsonNode * JsonParser_parseFile(struct JsonParser *parser, const char * fileName
         buffer = (char*) malloc (length + 1);
         if (buffer) {
             read = fread (buffer, sizeof(char), length, f);
-            buffer[length] = '\0';
+            buffer[read] = '\0';
         }
         fclose (f);
         if (read > 0) {


### PR DESCRIPTION
If file is opened in text mode "r" the number of read bytes can be smaller than the file size if the file contains Win line (CRLF) breaks.
